### PR TITLE
Use carthage bootstrap for setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 bundle install
-carthage build
+carthage checkout


### PR DESCRIPTION
`carthage build` just tries to build the modules that are already checked out
in `Carthage.checkout`. But `carthage bootstrap` is
`checkout + build`, so will download the dependencies we need then build them.
