### PR TITLE
Dismiss sync sheet when initial sync is completed

### DIFF
--- a/Poppins/Controllers/LinkAccountViewController.swift
+++ b/Poppins/Controllers/LinkAccountViewController.swift
@@ -6,7 +6,7 @@ class LinkAccountViewController: UIViewController {
         super.viewDidLoad()
 
         NSNotificationCenter.defaultCenter().addObserver(self, selector: "authSuccessful", name: AccountLinkedNotificationName, object: .None)
-        NSNotificationCenter.defaultCenter().addObserver(self, selector: "preloadCompleted", name: PreloadCompletedNotificationName, object: .None)
+        NSNotificationCenter.defaultCenter().addObserver(self, selector: "initialSyncCompleted", name: InitialSyncCompletedNotificationName, object: .None)
     }
 
     deinit {
@@ -21,7 +21,7 @@ class LinkAccountViewController: UIViewController {
         }
     }
 
-    func preloadCompleted() {
+    func initialSyncCompleted() {
         dispatch_async(dispatch_get_main_queue()) {
             _ = self.presentingViewController?.dismissViewControllerAnimated(true, completion: .None)
         }

--- a/Poppins/Models/SyncManager.swift
+++ b/Poppins/Models/SyncManager.swift
@@ -1,5 +1,6 @@
 public let AccountLinkedNotificationName = "PoppinsAccountLinked"
 let PreloadCompletedNotificationName = "PoppinsPreloadCompleted"
+let InitialSyncCompletedNotificationName = "PoppinsInitialSyncCompleted"
 
 public let ServiceKey = "PoppinsService"
 


### PR DESCRIPTION
If the user has no images, waiting for the preload to finish would mean that
the sync screen never gets dismissed. Instead, we should dismiss the screen
when the initial sync completes (meaning we have the data for the files that
will be downloaded but they haven't been downloaded yet).

This will be confusing for a bit until we get some sort of empty state screen
implemented. Right now, it will look like the app finishes
"syncing" then just does nothing. This is true no matter if you have images in
Dropbox or not. We should add copy to the empty state that directs the user to
add images to their Poppins folder in Dropbox, or to hang tight till we finish
downloading the ones that are already there.
