### PR TITLE
Delete objects from the managed object context

### DIFF
--- a/Poppins/Models/ImageStore.swift
+++ b/Poppins/Models/ImageStore.swift
@@ -22,4 +22,9 @@ struct ImageStore {
         store.insertObject(cachedImage)
         store.save()
     }
+
+    func deleteCachedImage(cachedImage: CachedImage) {
+        store.deleteObject(cachedImage)
+        store.save()
+    }
 }

--- a/Poppins/Models/Store.swift
+++ b/Poppins/Models/Store.swift
@@ -50,6 +50,12 @@ class Store {
         }
     }
 
+    func deleteObject<A: NSManagedObject>(object: A) {
+        managedObjectContext.performBlockAndWait {
+            self.managedObjectContext.deleteObject(object)
+        }
+    }
+
     func save() {
         managedObjectContext.performBlockAndWait {
             _ = self.managedObjectContext.save(nil);

--- a/Poppins/Models/SyncEngine.swift
+++ b/Poppins/Models/SyncEngine.swift
@@ -61,6 +61,6 @@ class SyncEngine {
     }
 
     private func deleteFile(cachedImage: CachedImage) {
-        cachedImage.delete(.None)
+        store.deleteCachedImage(cachedImage)
     }
 }


### PR DESCRIPTION
There was a bug such that when one deletes an image from Dropbox the app would
crash.  This is because there was not implementation to delete the object on
the phone. This adds the code to delete the object from core data.
