### PR TITLE
Rasterize the shadow

### DIFF
--- a/Poppins/Views/PoppinsCell.swift
+++ b/Poppins/Views/PoppinsCell.swift
@@ -46,6 +46,8 @@ extension PoppinsCell {
         shadowView?.layer.shadowOpacity = shadowOpacity
         shadowView?.layer.shadowOffset = shadowOffset
         shadowView?.layer.shadowRadius = shadowSpread
+        shadowView?.layer.shouldRasterize = true
+        shadowView?.layer.rasterizationScale = UIScreen.mainScreen().scale
     }
 }
 


### PR DESCRIPTION
This greatly improves the collection view scrolling performance. I also
tried setting the shadowPath but didn't know what to set the path to in
order to make it work. I set it to the bounds of shadowView but that
caused shadow to cast over other gifs and was generally weird.
