### PR TITLE
Remove custom install path

### DIFF
--- a/Poppins.xcodeproj/project.pbxproj
+++ b/Poppins.xcodeproj/project.pbxproj
@@ -937,7 +937,6 @@
 				);
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = "Poppins/Resources/Other-Sources/Info.plist";
-				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_CFLAGS = (
 					"-DNS_BLOCK_ASSERTIONS=1",
@@ -977,7 +976,6 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = "Poppins/Resources/Other-Sources/Info.plist";
-				INSTALL_PATH = "$(BUILT_PRODUCTS_DIR)";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
This has been causing archives to produce Xcode Generic Archives, which
cannot be submitted to the store directly.
